### PR TITLE
Handling of other actors

### DIFF
--- a/slack_notification/__init__.py
+++ b/slack_notification/__init__.py
@@ -35,7 +35,7 @@ class SlackNotifcationPlugin(Component):
 		#template = '%(project)s %(rev)s %(author)s: %(logmsg)s'
 		template = '_%(project)s_ :incoming_envelope: \n%(type)s <%(url)s|%(id)s>: %(summary)s [*%(action)s* by @%(author)s]'
 
-		cced=[]
+		cced=[];
 
 		if values['reporter'] and values['reporter'] not in cced and values['reporter'] != values['author']:
 			cced.append(values['reporter'])
@@ -46,9 +46,6 @@ class SlackNotifcationPlugin(Component):
 				if owner not in cced and owner != values['author']:
                                         cced.append(owner)
 		
-		#if values['owner'] and values['owner'] not in cced and values['owner'] != values['author']:
-		#	cced.append(values['owner'])
-
 		if values['cc']:
 			splitCC = values['cc'].replace(" ","").split(",")
 			for cc in splitCC:
@@ -74,7 +71,7 @@ class SlackNotifcationPlugin(Component):
 
 		if values.get('changes', False):
 			attachments.append({
-				'title': ':small_red_triangle: Changes',
+				'title': 'Changes',
 				'text': values['changes']
 			})
 

--- a/slack_notification/__init__.py
+++ b/slack_notification/__init__.py
@@ -35,6 +35,29 @@ class SlackNotifcationPlugin(Component):
 		#template = '%(project)s %(rev)s %(author)s: %(logmsg)s'
 		template = '_%(project)s_ :incoming_envelope: \n%(type)s <%(url)s|%(id)s>: %(summary)s [*%(action)s* by @%(author)s]'
 
+		cced=[]
+
+		if values['reporter'] and values['reporter'] not in cced and values['reporter'] != values['author']:
+			cced.append(values['reporter'])
+
+		if values['owner']:
+			splitOwner = values['owner'].replace(" ","").split(",")
+			for owner in splitOwner:
+				if owner not in cced and owner != values['author']:
+                                        cced.append(owner)
+		
+		#if values['owner'] and values['owner'] not in cced and values['owner'] != values['author']:
+		#	cced.append(values['owner'])
+
+		if values['cc']:
+			splitCC = values['cc'].replace(" ","").split(",")
+			for cc in splitCC:
+				if cc not in cced and cc != values['author']:
+					cced.append(cc)
+
+		if len(cced):
+			template += ' [CC: @' + ', @'.join(cced) + ' ] '
+
 		attachments = []
 
 		if values['action'] == 'closed':


### PR DESCRIPTION
The message now adds now author of comment, owner of the ticket, assigned and cc'ed people.

Removed that `:small_red_triangle:` as it should be more connected with fail builds or tests, as well our flow of tickets had additional review stage and its just missleading. 

ps. I m not a python dev so please be delicate ;p